### PR TITLE
Warning when call Rjb::load (ruby 2.0.0p0)

### DIFF
--- a/ext/extconf.h
+++ b/ext/extconf.h
@@ -1,8 +1,8 @@
 #ifndef EXTCONF_H
 #define EXTCONF_H
 #define HAVE_JNI_H 1
-#define HAVE_DL_H 1
+#define HAVE_NL_LANGINFO 1
 #define HAVE_SETLOCALE 1
 #define HAVE_GETENV 1
-#define RJB_RUBY_VERSION_CODE 187
+#define RJB_RUBY_VERSION_CODE 200
 #endif

--- a/ext/load.c
+++ b/ext/load.c
@@ -107,16 +107,16 @@ static int open_jvm(char* libpath)
     int sstat;
     VALUE* argv;
 
-    rb_require("dl");
+    rb_require("fiddle");
 #if !defined(RUBINIUS)
-    if (!rb_const_defined_at(rb_cObject, rb_intern("DL")))
+    if (!rb_const_defined_at(rb_cObject, rb_intern("Fiddle")))
     {
 	rb_raise(rb_eRuntimeError, "Constants DL is not defined.");
 	return 0;
     }
 #endif
     argv = ALLOCA_N(VALUE, 4);
-    *argv = rb_const_get(rb_cObject, rb_intern("DL"));
+    *argv = rb_const_get(rb_cObject, rb_intern("Fiddle"));
     *(argv + 1) = rb_intern("dlopen");
     *(argv + 2) = 1;
     *(argv + 3) = rb_str_new2(libpath);


### PR DESCRIPTION
Run rjb in ruby version 2.0 (change DL to Fiddle, because DL is deprecated in rails 2.0).

Follows the warning:

> require 'rjb'
> => true
> Rjb::load
> DL is deprecated, please use Fiddle
> => nil
