### PR TITLE
New build routines

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+require 'rubygems/package_task'
+
+load './rjb.gemspec'
+
+Gem::PackageTask.new(RJB_GEMSPEC) do |pkg|
+  pkg.gem_spec = RJB_GEMSPEC
+  pkg.need_zip = false
+  pkg.need_tar = false
+end
+
+desc 'Default Task'
+task :default => :package

--- a/lib/rjb/version.rb
+++ b/lib/rjb/version.rb
@@ -1,0 +1,23 @@
+module Rjb
+  class << self
+
+    private
+
+    # @return [String, nil] the valid version number. Can be nil.
+    def read_version
+      path = File.expand_path('../../../ext/rjb.c', __FILE__)
+      File.open(path) do |f|
+        f.each_line do |l|
+          m = /RJB_VERSION\s+"(.+?)"/.match(l)
+
+          # The file is closed even in this case.
+          return m[1] if m
+        end
+      end
+    end
+  end
+
+  unless (VERSION = read_version)
+    raise 'Cannot find a valid version number in `rjb.c`!'
+  end
+end

--- a/lib/rjb/version.rb
+++ b/lib/rjb/version.rb
@@ -17,7 +17,11 @@ module Rjb
     end
   end
 
-  unless (VERSION = read_version)
-    raise 'Cannot find a valid version number in `rjb.c`!'
+  # The `Rjb` module defines `VERSION` in the C code.
+  # If Rjb is already required we have the constant.
+  unless defined?(::Rjb::VERSION)
+    unless (VERSION = read_version)
+      raise 'Cannot find a valid version number in `rjb.c`!'
+    end
   end
 end

--- a/rjb.gemspec
+++ b/rjb.gemspec
@@ -1,0 +1,51 @@
+lib_path = File.expand_path(File.join(File.dirname(__FILE__), 'lib'))
+$LOAD_PATH.unshift(lib_path) unless $LOAD_PATH.include?(lib_path)
+
+require 'rake'
+require 'rjb/version'
+
+RJB_GEMSPEC = Gem::Specification.new do |s|
+  s.author = 'arton'
+  s.email = 'artonx@gmail.com'
+  s.name = 'rjb'
+  s.description = 'RJB is a Bridge library which connects Ruby and Java'\
+                  ' code using the Java Native Interface.'
+  s.summary = 'Ruby Java Bridge'
+  s.homepage = 'http://www.artonx.org/collabo/backyard/?RubyJavaBridge'
+  s.version = Rjb::VERSION
+  s.require_path = 'lib'
+  # @todo We need a meaningful explanation for the end user.
+  s.requirements << 'JDK 5.0'
+  s.license = 'LGPL-2.1'
+  # @todo Do we need to support these old versions?
+  s.required_ruby_version = '>= 1.8.2'
+  # @todo Do we really need all the source code?
+  s.files = FileList['ext/*.java', 'ext/*.c', 'ext/*.h', 'ext/depend',
+                     'data/rjb/**/*.class', 'lib/*.rb', 'lib/rjb/*.rb',
+                     'samples/**/*.rb', 'test/*.rb', 'test/**/*.class',
+                     'test/*.jar', 'COPYING', 'ChangeLog', 'readme.*',
+                     'README.md']
+
+  # @todo We need some restrictions for JRuby and other plattforms
+  #   following RbConfig::CONFIG['host_os'] definitions.
+  #   A possible better solution is `rake-compiler`.
+  case RUBY_PLATFORM
+  when /mswin/
+    s.platform = Gem::Platform::CURRENT
+    FileUtils.cp 'ext/rjbcore.so', 'lib/rjbcore.so'
+    files << 'lib/rjbcore.so'
+    # @todo We need a meaningful explanation for the end user.
+    s.requirements << 'VC6 version of Ruby'
+  when /mingw/
+    s.platform = Gem::Platform::CURRENT
+    FileUtils.cp 'ext/rjbcore.so', 'lib/rjbcore.so'
+    files << 'lib/rjbcore.so'
+  when /darwin/
+    s.platform = Gem::Platform::CURRENT
+    FileUtils.cp 'ext/rjbcore.bundle', 'lib/rjbcore.bundle'
+    files << 'lib/rjbcore.bundle'
+  else
+    s.platform = Gem::Platform::RUBY
+    s.extensions << 'ext/extconf.rb'
+  end
+end

--- a/rjb.rake
+++ b/rjb.rake
@@ -41,7 +41,7 @@ spec = Gem::Specification.new do |s|
   s.requirements << 'JDK 5.0'
   s.license = 'LGPL'
   files = FileList['ext/*.java', 'ext/*.c', 'ext/*.h', 'ext/depend',
-                   'data/rjb/**/*.class', 'lib/*.rb', 'lib/rjb/*.rb', 'samples/**/*.rb', 
+                   'data/rjb/**/*.class', 'lib/*.rb', 'lib/rjb/*.rb', 'samples/**/*.rb',
                    'test/*.rb', 'test/**/*.class', 'test/*.jar', 'COPYING', 'ChangeLog', 'readme.*']
   if /mswin|mingw/ =~ RUBY_PLATFORM
     FileUtils.cp 'ext/rjbcore.so', 'lib/rjbcore.so'


### PR DESCRIPTION
Hello @arton 

I took the chance to look at the build routines in `Rjb` and tried to rework you code in some aspects which would in my oppinion facilitate the development of your wonderful library.

I split up your Rake tasks to provide a standalone Gemspec which could be used via `gem build ...` and separated other code into a `Rakefile` which is rather standard today in all Ruby based projects.

I would like to incorporate crosscompilation using `rake-compiler` and continuous integration for this project since the release history does not show a consistant release graph for all supported plattforms.

Another idea is to completely move to a fat binary gem: The java code is already precompiled for all planforms, the C code is also precompiled for Windows and MacOS computers. So we could include the Unix binaries as well.

We could also separate the runtime and compiletime files and provide only runtime files inside the gem. I think people who want to test and develop the library should rather look at the repository and not get the code via a Rubygems download.

Please let me know what do you think. Feel free not to accept my view :)