### PR TITLE
Use "javac -h" over "javah" as the latter is deprecated in Java 10.

### DIFF
--- a/ext/depend
+++ b/ext/depend
@@ -1,9 +1,15 @@
+JAVAH := $(shell command -v javah 2>/dev/null)
+
 riconv.o : riconv.c jp_co_infoseek_hp_arton_rjb_RBridge.h
 rjb.o : rjb.c jp_co_infoseek_hp_arton_rjb_RBridge.h riconv.h rjb.h
 rjbexception.o : rjbexception.c jp_co_infoseek_hp_arton_rjb_RBridge.h riconv.h rjb.h
 load.o : load.c jp_co_infoseek_hp_arton_rjb_RBridge.h
 jp_co_infoseek_hp_arton_rjb_RBridge.h : jniwrap.h ../data/rjb/jp/co/infoseek/hp/arton/rjb/RBridge.class
+ifdef JAVAH
 	javah -classpath ../data/rjb jp.co.infoseek.hp.arton.rjb.RBridge
+else
+	javac -h . -classpath ../data/rjb RBridge.java
+endif
 ../data/rjb/jp/co/infoseek/hp/arton/rjb/RBridge.class : RBridge.java
 	mkdir -p ../data/rjb/jp/co/infoseek/hp/arton/rjb
 	javac -d ../data/rjb RBridge.java


### PR DESCRIPTION
```
The javah tool was deprecated as of JDK 9 [0] and has been removed in in JDK
10.

This was originally filed in Debian as #897664.

  [0] https://docs.oracle.com/javase/9/tools/javah.htm#JSWOR687
  [1] https://bugs.debian.org/897664
```