### PR TITLE
fix #85 recreate Gem by original bridge class

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Fri Apr 8 2022 arton
+ fix #85
+ * data/rjb/jp/co/infoseek/hp/arton/rjb/RBridge.class
+	Gem rebuild by original  binary (build by javac 1.4.2)
+ * ext/rjb.c
+	RJB_VERSION -> 1.6.5 (not changed any other codes but for Gem)
 Sun Feb 7 2021 arton
  * ext/extconf.rb
 	use javah if `javac -version` didn't return the version number (ex. 1.4.2)

--- a/ext/rjb.c
+++ b/ext/rjb.c
@@ -14,7 +14,7 @@
  *
  */
 
-#define RJB_VERSION "1.6.4"
+#define RJB_VERSION "1.6.5"
 
 #include "ruby.h"
 #include "extconf.h"


### PR DESCRIPTION
I built Rjb gem with JDK11 compiled version of RBridge.
Therefore the gem lacks widly compatibility of Java environment.
This PR is for Gem version update patch.