### PR TITLE
Add support for more ARM64v8 variants

### DIFF
--- a/ext/load.c
+++ b/ext/load.c
@@ -82,7 +82,10 @@
   #define ARCH "i386"
  #elif defined(__arm__)
   #define ARCH "arm"
- #elif defined(__aarch64__) || defined(__arm64v8__)
+ #elif defined(__ARM64_ARCH_8__)
+    || defined(__aarch64__)
+    || defined(__ARMv8__)
+    || defined(__ARMv8_A__)
    #define ARCH "aarch64"
    #undef JVM_TYPE
    #define JVM_TYPE "server"

--- a/ext/load.c
+++ b/ext/load.c
@@ -82,7 +82,7 @@
   #define ARCH "i386"
  #elif defined(__arm__)
   #define ARCH "arm"
- #elif defined(__aarch64__)
+ #elif defined(__aarch64__) || defined(__arm64v8__)
    #define ARCH "aarch64"
    #undef JVM_TYPE
    #define JVM_TYPE "server"


### PR DESCRIPTION
This should hopefully allow the extension to be built with the official Ruby ARM64v8 image