### PR TITLE
Add ruby 3.2 support

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -40,7 +40,7 @@ unless javahome.nil?
   raise "JAVA_HOME is not directory." unless File.directory?(javahome)
   pt = Path.new
   inc = pt.include(javahome, 'include')
-  if !File.exists?(inc) && RUBY_PLATFORM =~ /darwin/
+  if !File.exist?(inc) && RUBY_PLATFORM =~ /darwin/
     inc = pt.include('/System/Library/Frameworks/JavaVM.framework', 'Headers')
   end
   Dir.open(inc).each do |d|


### PR DESCRIPTION
`File.exists?` [has been removed])https://bugs.ruby-lang.org/issues/17391)

Use `File.exist?` instead.

<img width="643" alt="image" src="https://user-images.githubusercontent.com/1371733/209479984-13442c15-4b3c-4c01-a8e5-322563f7fb4a.png">
