### PR TITLE
Fix aarch64 checking exception

### DIFF
--- a/ext/load.c
+++ b/ext/load.c
@@ -82,10 +82,7 @@
   #define ARCH "i386"
  #elif defined(__arm__)
   #define ARCH "arm"
- #elif defined(__ARM64_ARCH_8__)
-    || defined(__aarch64__)
-    || defined(__ARMv8__)
-    || defined(__ARMv8_A__)
+ #elif defined(__ARM64_ARCH_8__) || defined(__aarch64__) || defined(__ARMv8__) || defined(__ARMv8_A__)
    #define ARCH "aarch64"
    #undef JVM_TYPE
    #define JVM_TYPE "server"


### PR DESCRIPTION
Hi @arton 
rjb can not installed on aarch64, checked it was a syntax error, please help merge into master and bump version.