### PR TITLE
Readme fixes for a broken/non-supported URL and a typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ On Unix based machines plese see `test/readme.unix`. You need to set
 
 If you'll plan to open the non-ascii character named file by Java
 class through Rjb, it may require to set LC_ALL environment variable
-in you sciprt.
+in your script.
 
 For example in Rails, set above line in `production.rb` as your environment:
 
@@ -58,7 +58,7 @@ For example in Rails, set above line in `production.rb` as your environment:
 ENV['LC_ALL'] = 'en_us.utf8' # or ja_JP.utf8 etc.
 ```
 
-cf: http://bugs.sun.com/view_bug.do?bug_id=4733494
+cf: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4733494
    (Thanks Paul for this information).
 
 # Contact

--- a/readme.txt
+++ b/readme.txt
@@ -28,10 +28,10 @@ see test/readme.unix
 you must set LD_LIBRARY_PATH environmental variable to run rjb.
 
 -- Notice for opening non-ASCII 7bit filename
-If you'll plan to open the non-ascii character named file by Java class through Rjb, it may require to set LC_ALL environment variable in you sciprt.
+If you'll plan to open the non-ascii character named file by Java class through Rjb, it may require to set LC_ALL environment variable in your script.
 For example in Rails, set above line in production.rb as your environment.
 ENV['LC_ALL'] = 'en_us.utf8' # or ja_JP.utf8 etc.
- cf: http://bugs.sun.com/view_bug.do?bug_id=4733494
+ cf: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4733494
    (Thanks Paul for this information).
 
 artonx@yahoo.co.jp


### PR DESCRIPTION
Hello @arton San!

As mentioned in the PR title, fixed below in `README.md` and `readme.txt`:
 - A URL referring to a bug for 'LC_ALL' setting was broken.
 - Minor typo correction in the documentation.
