### PR TITLE
fix #100 (reported by uvlad7, thanks!)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,15 @@
+Sun Apr 14 2024 arton
+ * ext/rjb.c
+	RJB_VERSION -> 1.7.0
+	java2jniname replaces second '.' to '$' for nested/inner classes
+ * test/test.rb
+	add test_load_nested/inner_class_as_java_naming_convention
 Thu Nov 9 2023 arton
  * ext/rjb.c
 	RJB_VERSION -> 1.6.9
  * ext/riconv.c
 	fix CESU-8 check
- * test/est.rb
+ * test/test.rb
 	add test_jav_hangul_syllable for checking CESU-8 bug (char start with 0xed)
 Thu Sep 28 2023 chaddow
  #93 fake allocation framework to remove T_DATA warning

--- a/ext/rjb.c
+++ b/ext/rjb.c
@@ -14,7 +14,7 @@
  *
  */
 
-#define RJB_VERSION "1.6.9"
+#define RJB_VERSION "1.7.0"
 
 #include "ruby.h"
 #include "extconf.h"
@@ -185,11 +185,16 @@ void rjb_release_string(JNIEnv *jenv, jstring str, const char* chrs)
 static char* java2jniname(char* jnicls)
 {
     char* p;
+    int found_class_separator = isupper(*jnicls) ? 1 : 0;
     for (p = jnicls; *p; p++)
     {
 	if (*p == '.')
 	{
-	    *p = '/';
+	    if (isupper(*(p + 1)))
+	    {
+	        found_class_separator++;
+	    }
+	    *p = (found_class_separator <= 1) ? '/' : '$';
 	}
     }
     return jnicls;

--- a/test/test.rb
+++ b/test/test.rb
@@ -986,4 +986,15 @@ class TestRjb < Test::Unit::TestCase
       assert_false e.respond_to? :unknown_method
     end
   end
+
+  def test_load_nested_class_as_java_convention
+    tstate = import('java.lang.Thread.State')
+    assert_equal(tstate.BLOCKED.ordinal, 2)
+    assert_equal(tstate.BLOCKED.name, 'BLOCKED')
+  end
+
+  def test_load_inner_class_as_java_convention
+    tes = import('java.util.HashMap.EntrySet')
+    assert_equal(tes._classname, 'java.lang.Class')
+  end
 end


### PR DESCRIPTION
#100 reported by uvlad7
Rjb takes Java style class name for imporing. However it forces to call JNI naming convention fo nested classes and inner classes such as 'a.b.C$X'.
This patch changes above behaviour.
After Rjb 1.7.0, it simply call as 'a.b.C.X' as Java does.