### PR TITLE
fix #95 accept original encoding (reported by winezer0)

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -79,8 +79,8 @@ end
 JAVAH_COMMAND = 'javac -h . -classpath ../data/rjb RBridge.java'.freeze
 
 if find_executable('javah')
-  cversion = (`javac -version` =~ /\d+\.\d+\.\d+/ ) ? $& : nil
-  hversion = (`javah -version` =~ /\d+\.\d+\.\d+/ )  ? $& : nil
+  cversion = (`javac -version`.force_encoding(Encoding.locale_charmap).encode('utf-8') =~ /\d+\.\d+\.\d+/ ) ? $& : nil
+  hversion = (`javah -version`.force_encoding(Encoding.locale_charmap).encode('utf-8') =~ /\d+\.\d+\.\d+/ )  ? $& : nil
   if cversion == hversion || cversion.nil?
     javah = 'javah -classpath ../data/rjb jp.co.infoseek.hp.arton.rjb.RBridge'
   else

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -79,8 +79,13 @@ end
 JAVAH_COMMAND = 'javac -h . -classpath ../data/rjb RBridge.java'.freeze
 
 if find_executable('javah')
-  cversion = (`javac -version`.force_encoding(Encoding.locale_charmap).encode('utf-8') =~ /\d+\.\d+\.\d+/ ) ? $& : nil
-  hversion = (`javah -version`.force_encoding(Encoding.locale_charmap).encode('utf-8') =~ /\d+\.\d+\.\d+/ )  ? $& : nil
+  if defined?(Encoding) && ''.respond_to?(:force_encoding)
+    cversion = (`javac -version`.force_encoding(Encoding.locale_charmap).encode('utf-8') =~ /\d+\.\d+\.\d+/ ) ? $& : nil
+    hversion = (`javah -version`.force_encoding(Encoding.locale_charmap).encode('utf-8') =~ /\d+\.\d+\.\d+/ )  ? $& : nil
+  else
+    cversion = (`javac -version` =~ /\d+\.\d+\.\d+/ ) ? $& : nil
+    hversion = (`javah -version` =~ /\d+\.\d+\.\d+/ )  ? $& : nil
+  end
   if cversion == hversion || cversion.nil?
     javah = 'javah -classpath ../data/rjb jp.co.infoseek.hp.arton.rjb.RBridge'
   else

--- a/ext/load.c
+++ b/ext/load.c
@@ -95,7 +95,6 @@
  #define DIRSEPARATOR '/'
  #define CLASSPATH_SEP ':'
 #endif
-
 #if defined(__APPLE__) && defined(__MACH__)
  static char* CREATEJVM = "JNI_CreateJavaVM";
  static char* GETDEFAULTJVMINITARGS = "JNI_GetDefaultJavaVMInitArgs";
@@ -106,7 +105,6 @@
 
 typedef int (JNICALL *GETDEFAULTJAVAVMINITARGS)(void*);
 typedef int (JNICALL *CREATEJAVAVM)(JavaVM**, JNIEnv**, void*);
-
 
 static VALUE jvmdll = Qnil;
 static VALUE getdefaultjavavminitargsfunc;
@@ -274,7 +272,7 @@ static int load_jvm(const char* jvmtype)
         return 1;
     }
 #if defined(_WIN32) || defined(__CYGWIN__)
-    return 0;
+    sprintf(libpath, JVMDLL, java_home, jvmtype);
 #else /* not Windows / MAC OS-X */
     sprintf(libpath, JVMDLL, java_home, ARCH, jvmtype);
 #endif

--- a/ext/rjb.c
+++ b/ext/rjb.c
@@ -1,6 +1,6 @@
 /*
  * Rjb - Ruby <-> Java Bridge
- * Copyright(c) 2004,2005,2006,2007,2008,2009,2010,2011,2012,2014-2016,2018 arton
+ * Copyright(c) 2004,2005,2006,2007,2008,2009,2010,2011,2012,2014-2016,2018,2024 arton
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -14,7 +14,7 @@
  *
  */
 
-#define RJB_VERSION "1.7.1"
+#define RJB_VERSION "1.7.2"
 
 #include "ruby.h"
 #include "extconf.h"

--- a/lib/rjb/extension.rb
+++ b/lib/rjb/extension.rb
@@ -58,7 +58,7 @@ module Kernel
     end
     raise unless found_path
 
-    abs_path = File.join(found_path, path)
+    abs_path = found_path.length == 0 ? path : File.join(found_path, path)
     # check that the file exists
     raise unless  File.exist?(abs_path)
 

--- a/setup.rb
+++ b/setup.rb
@@ -356,7 +356,6 @@ class ConfigTable_class   # open again
     'site-ruby-common' => 'siteruby',     # For backward compatibility
     'site-ruby'        => 'siterubyver',  # For backward compatibility
     'bin-dir'          => 'bindir',
-    'bin-dir'          => 'bindir',
     'rb-dir'           => 'rbdir',
     'so-dir'           => 'sodir',
     'data-dir'         => 'datadir',


### PR DESCRIPTION
#95 Windows javah and javac output contains its code page. 

To support elder version of ruby, it should check 'blabla'.respond_to?(:force_encoding) etc.