### PR TITLE
fix #105 add extra parameter to invoke_by_instance 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+Wed May 1 2024 arton (reported and designed by uvlad7)
+ * test/Test105.java
+	add for test #105 (uvald7)
+ * test/test105.rb
+	add for test #105 (uvald7)
+ * ext/rjb.c
+	RJV_VERSION -> 1.7.3
+	invoke_by_instance takes six parameters. six is called by method_missing or _invoke
 Wed May 1 2024 arton
  * test/jartest3.rb
 	accept ClassNotFoundException for test

--- a/ext/rjb.c
+++ b/ext/rjb.c
@@ -14,7 +14,7 @@
  *
  */
 
-#define RJB_VERSION "1.7.2"
+#define RJB_VERSION "1.7.3"
 
 #include "ruby.h"
 #include "extconf.h"
@@ -3093,14 +3093,14 @@ static VALUE invoke(JNIEnv* jenv, struct cls_method* pm, struct jvi_data* ptr,
  * Object invocation
  */
 static VALUE invoke_by_instance(ID rmid, int argc, VALUE* argv,
-				struct jvi_data* ptr, char* sig)
+				struct jvi_data* ptr, char* sig, int called_by_invoke)
 {
     VALUE ret = Qnil;
     JNIEnv* jenv = rjb_attach_current_thread();
     struct cls_field* pf;
     struct cls_method* pm;
     const char* tname = rb_id2name(rmid);
-    if (argc == 0 && st_lookup(ptr->fields, rmid, (st_data_t*)&pf))
+    if (!called_by_invoke && argc == 0 && st_lookup(ptr->fields, rmid, (st_data_t*)&pf))
     {
         ret = getter(jenv, pf, ptr);
     }
@@ -3157,7 +3157,7 @@ static VALUE rjb_i_invoke(int argc, VALUE* argv, VALUE self)
     sig = NIL_P(vsig) ? NULL :  StringValueCStr(vsig);
     Data_Get_Struct(self, struct jvi_data, ptr);
 
-    return invoke_by_instance(rmid, argc - 2, argv + 2, ptr, sig);
+    return invoke_by_instance(rmid, argc - 2, argv + 2, ptr, sig, 1);
 }
 
 static VALUE rjb_i_missing(int argc, VALUE* argv, VALUE self)
@@ -3167,7 +3167,7 @@ static VALUE rjb_i_missing(int argc, VALUE* argv, VALUE self)
 
     Data_Get_Struct(self, struct jvi_data, ptr);
 
-    return invoke_by_instance(rmid, argc -1, argv + 1, ptr, NULL);
+    return invoke_by_instance(rmid, argc -1, argv + 1, ptr, NULL, 0);
 }
 
 /*

--- a/test/Test105.java
+++ b/test/Test105.java
@@ -1,0 +1,10 @@
+package jp.co.infoseek.hp.arton.rjb;
+public class Test105 {
+    public String test;
+    public Test105(String test) {
+	this.test = test;
+    }
+    public String test() {
+	return "method_" + test;
+    }
+}

--- a/test/test105.rb
+++ b/test/test105.rb
@@ -1,0 +1,28 @@
+begin
+  require 'rjb'
+rescue LoadError
+  require 'rubygems'
+  require 'rjb'
+end
+require 'test/unit'
+
+class Test105 < Test::Unit::TestCase
+  include Rjb
+  def setup
+    Rjb::load('.')
+    @test105 = import('jp.co.infoseek.hp.arton.rjb.Test105')
+  end
+
+  def test_field
+    test = @test105.new('xyz')
+    assert_equal('xyz', test.test)
+  end
+
+  def test_method
+    test = @test105.new('xyz')
+    ret = test._invoke('test')
+    assert_equal('method_xyz', ret)
+  end
+end
+
+    


### PR DESCRIPTION
#105 add extra parameter to invoke_by_instance. it indicates that the function was called by missing or _invoke.
if no arguments were given, it the indicator was1, it should be method not field. 
reported and designed by uvlad7